### PR TITLE
Use routes.draw instead of routes.prepend

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,6 @@
-Spree::Core::Engine.routes.prepend do
-
+Spree::Core::Engine.routes.draw do
   namespace :admin do
     resources :log_entries
   end
-  
 end
 


### PR DESCRIPTION
There's no need to use routes.prepend, which causes some issues in rails 4: rails/rails#11895
